### PR TITLE
html wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Hook::stop();
 Put in a hook listener it stops the running of the other listeners that are registered to this hook.
 
 
-# Wrap html
+# Wrap HTML
 ```php
 @hook('hookName', true)
     this content can be modified with dom parsers

--- a/README.md
+++ b/README.md
@@ -47,24 +47,23 @@ then to the app.php :
 Example:
 
 ```php
-    $user = new User();
-    $user = Hook::get('fillUser',[$user],function($user)
-    {
-     return $user;
-    });
+$user = new User();
+$user = Hook::get('fillUser',[$user],function($user){
+    return $user;
+});
 ```
 
 In this case a fillUser hook is thrown, which receive the $user object as a parameter. If nothing catches it, the internal function, the return $user will run, so nothing happens. But it can be caught by a listener from a provider:
 
 ```php
-        Hook::listen('fillUser', function ($callback, $output, $user) {
-            if (empty($output))
-            {
-              $output = $user;
-            }
-            $output->profilImage = ProfilImage::getForUser($user->id);
-            return $output;
-        }, 10);
+Hook::listen('fillUser', function ($callback, $output, $user) {
+    if (empty($output))
+    {
+      $output = $user;
+    }
+    $output->profilImage = ProfilImage::getForUser($user->id);
+    return $output;
+}, 10);
 
 ```
 The $callback contains the hook's original internal function, so it can be called here.
@@ -77,6 +76,30 @@ The hook listener above caught the call of the fillUser, extended the received o
 
 Number 10 in the example is the priority. They are executed in an order, so if a number 5 is registered to the fillUser as well, it will run before number 10.
 
+
+# Initial output
+
+You can pass initial output to the listeners too.
+
+```php
+$initialOutput='test string';
+
+\Hook::get('testing',['other string'],function($user){
+    return $user;
+},$initialOutput)
+
+// and later ...
+
+Hook::listen('testing', function ($callback, $output, $otherString) {
+    if ($output==='test string') {
+        $output="{$output} yeeeaaaayyy!";
+    }
+    if ($otherString==='other_string') {
+        // other string is good too
+    }
+    return $output; // 'test string yeeeaaaayyy!'
+});
+```
 
 
 # Usage in blade templates
@@ -93,15 +116,7 @@ In this case the hook listener can catch it like this:
 ```
 In the $variables variable it receives all of the variables that are available for the blade template.
 
-**To listen blade templates you need to listen template.hookName instead of just hookName!**
-
-
-# Stop
-```php
-Hook::stop();
-```
-Put in a hook listener it stops the running of the other listeners that are registered to this hook.
-
+:exclamation: **To listen blade templates you need to listen `template.hookName` instead of just `hookName`!**
 
 # Wrap HTML
 ```php
@@ -116,6 +131,15 @@ Hook::listen('template.hookName', function ($callback, $output, $variables) {
   return "<div class=\"alert alert-success\">$output</div>";
 });
 ```
+
+
+# Stop
+```php
+Hook::stop();
+```
+Put in a hook listener it stops the running of the other listeners that are registered to this hook.
+
+
 
 # For testing
 

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ You can pass initial output to the listeners too.
 ```php
 $initialOutput='test string';
 
-\Hook::get('testing',['other string'],function($user){
-    return $user;
+\Hook::get('testing',['other string'],function($otherString){
+    return $otherString;
 },$initialOutput)
 
 // and later ...
@@ -100,7 +100,7 @@ Hook::listen('testing', function ($callback, $output, $otherString) {
     return $output; // 'test string yeeeaaaayyy!'
 });
 ```
-
+If there is no listeners, 'other string' will be returned.
 
 # Usage in blade templates
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ It is similar to an event. A code bounded by a hook runs unless a hook listener 
 **What is it good for?**
 
 Example 1: You have a module which displays an editor. This remains the same editor in every case.
-If you bound the display of the editor in a hook, then you can write a module which can redefine/override this hook, and for example changs the textarea to a ckeditor. 
+If you bound the display of the editor in a hook, then you can write a module which can redefine/override this hook, and for example changs the textarea to a ckeditor.
 
-Example 2: You list the users. You can include every line's print in a hook. This way you can write a separate module which could extend this line with an e-mail address print. 
+Example 2: You list the users. You can include every line's print in a hook. This way you can write a separate module which could extend this line with an e-mail address print.
 
-Example 3: You save the users' data in a database. If you do it in a hook, you can write a module which could add extra fields to the user model like "first name" or "last name". To do that, you didn't need to modify the code that handles the users, the extension module doesn't need to know the functioning of the main module. 
+Example 3: You save the users' data in a database. If you do it in a hook, you can write a module which could add extra fields to the user model like "first name" or "last name". To do that, you didn't need to modify the code that handles the users, the extension module doesn't need to know the functioning of the main module.
 
 
 ... and so many other things. If you are building a CMS-like system, it will make your life a lot easier.
@@ -29,7 +29,7 @@ composer require esemve/hook
 then to the app.php :
 ```php
 ...
-'providers' => [ 
+'providers' => [
     ...
     Esemve\Hook\HookServiceProvider::class,
     ...
@@ -100,7 +100,22 @@ In the $variables variable it receives all of the variables that are available f
 ```php
 Hook::stop();
 ```
-Put in a hook listener it stops the running of the other listeners that are registered to this hook. 
+Put in a hook listener it stops the running of the other listeners that are registered to this hook.
+
+
+# Wrap html
+```php
+@hook('hookName', true)
+    this content can be modified with dom parsers
+    you can inject some html here
+@endhook
+```
+Now the `$output` parameter contains html wrapped by hook component.
+```php
+Hook::listen('template.hookName', function ($callback, $output, $variables) {
+  return "<div class=\"alert alert-success\">$output</div>";
+});
+```
 
 # For testing
 

--- a/src/Callback.php
+++ b/src/Callback.php
@@ -7,7 +7,6 @@ class Callback
     protected $function;
     protected $parameters = [];
     protected $run = true;
-    protected $output = null;
 
     public function __construct($function, $parameters = [])
     {

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -16,7 +16,7 @@ class Hook
      * @param callable $callback
      * @return null|void
      */
-    public function get($hook, $params = [], callable $callback = null)
+    public function get($hook, $params = [], callable $callback = null, $htmlContent = '')
     {
         $callbackObject = $this->createCallbackObject($callback, $params);
 
@@ -25,7 +25,7 @@ class Hook
             return $output;
         }
 
-        $output = $this->run($hook, $params, $callbackObject);
+        $output = $this->run($hook, $params, $callbackObject, $htmlContent);
 
         if (!$output) {
             $output = $callbackObject->call();
@@ -147,13 +147,10 @@ class Hook
      * @param \Esemve\Hook\Callback $callback Callback object
      * @return mixed
      */
-    protected function run($hook, $params, Callback $callback)
+    protected function run($hook, $params, Callback $callback, $output = null)
     {
-        $output = null;
         array_unshift($params, $output);
         array_unshift($params, $callback);
-
-        $params[1] = '';
 
         if (array_key_exists($hook, $this->watch)) {
             if (is_array($this->watch[$hook])) {
@@ -162,7 +159,9 @@ class Hook
                         unset($this->stop[$hook]);
                         break;
                     }
-
+                    if($output){
+                        //var_dump($params);
+                    }
                     $output = call_user_func_array($function['function'], $params);
                     $params[1] = $output;
                 }

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -14,6 +14,7 @@ class Hook
      * @param string $hook Hook name
      * @param array $params
      * @param callable $callback
+     * @param string $htmlContent content wrapped by hook
      * @return null|void
      */
     public function get($hook, $params = [], callable $callback = null, $htmlContent = '')
@@ -145,6 +146,7 @@ class Hook
      * @param string $hook Hook name
      * @param array $params Parameters
      * @param \Esemve\Hook\Callback $callback Callback object
+     * @param string $output html wrapped by hook
      * @return mixed
      */
     protected function run($hook, $params, Callback $callback, $output = null)
@@ -159,9 +161,7 @@ class Hook
                         unset($this->stop[$hook]);
                         break;
                     }
-                    if($output){
-                        //var_dump($params);
-                    }
+
                     $output = call_user_func_array($function['function'], $params);
                     $params[1] = $output;
                 }

--- a/src/HookServiceProvider.php
+++ b/src/HookServiceProvider.php
@@ -32,7 +32,9 @@ class HookServiceProvider extends ServiceProvider
 
             $name = trim($parameters[0], "'");
 
-            return ' <' . '?php
+            // $parameters[1] => bool => is this wrapper component?
+            if (!isset($parameters[1])) {
+                return ' <' . '?php
 
                 $__definedVars = (get_defined_vars()["__data"]);
                 if (empty($__definedVars))
@@ -42,7 +44,30 @@ class HookServiceProvider extends ServiceProvider
                 $output = \Hook::get("template.'.$name.'",["data"=>$__definedVars],function($data) { return null; });
                 if ($output)
                 echo $output;
-            ?' . '>';
+                ?' . '>';
+            }else{
+                return ' <' . '?php
+                    $__hook_name="'.$name.'";
+                    ob_start();
+                ?' . '>';
+            }
+        });
+
+        Blade::directive('endhook',function($parameter){
+
+            return ' <'.'?php
+                $__definedVars = (get_defined_vars()["__data"]);
+                if (empty($__definedVars))
+                {
+                    $__definedVars = [];
+                }
+                $__hook_content = ob_get_clean();
+                $output = \Hook::get("template.$__hook_name",["data"=>$__definedVars],function($data) { return null; },$__hook_content);
+                unset($__hook_name);
+                unset($__hook_content);
+                if ($output)
+                echo $output;
+                ?'.'>';
         });
     }
 }


### PR DESCRIPTION
```php
@hook('hookName', true)
    this content can be modified with dom parsers
    you can inject some html here
@endhook
```
Now the `$output` parameter contains html wrapped by hook component.
```php
Hook::listen('template.hookName', function ($callback, $output, $variables) {
  return "<div class=\"alert alert-success\">$output</div>";
});
```