### PR TITLE
Fix error when hook listeners are on an include/require.

### DIFF
--- a/src/Hook.php
+++ b/src/Hook.php
@@ -2,6 +2,8 @@
 
 namespace Esemve\Hook;
 
+use Illuminate\Support\Arr;
+
 class Hook
 {
     protected $watch = [];
@@ -77,7 +79,7 @@ class Hook
             'caller'   => [
                 //'file' => $caller['file'],
                 //'line' => $caller['line'],
-                'class' => array_get($caller, 'class'),
+                'class' => Arr::get($caller, 'class'),
             ],
         ];
 

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -58,7 +58,11 @@ class Hook
      */
     public function listen($hook, $function, $priority = null)
     {
-        $caller = debug_backtrace()[2];
+        $caller = debug_backtrace(null, 3)[2];
+
+        if (in_array(array_get($caller, 'function'), ['include', 'require'])) {
+            $caller = debug_backtrace(null, 4)[3];
+        }
 
         if (empty($this->watch[$hook])) {
             $this->watch[$hook] = [];
@@ -73,7 +77,7 @@ class Hook
             'caller'   => [
                 //'file' => $caller['file'],
                 //'line' => $caller['line'],
-                'class' => $caller['class'],
+                'class' => array_get($caller, 'class'),
             ],
         ];
 

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -62,7 +62,7 @@ class Hook
     {
         $caller = debug_backtrace(null, 3)[2];
 
-        if (in_array(array_get($caller, 'function'), ['include', 'require'])) {
+        if (in_array(Arr::get($caller, 'function'), ['include', 'require'])) {
             $caller = debug_backtrace(null, 4)[3];
         }
 


### PR DESCRIPTION
Was using includes to swap out what hooks listeners were being used. Encountered a bug where class isn't in the expected traceback index. So've done a check to see if it's a include/require then switch to the correct index.