### PR TITLE
Handle wildcards in hook names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+!.gitignore
+.idea

--- a/README.md
+++ b/README.md
@@ -132,6 +132,30 @@ Hook::listen('template.hookName', function ($callback, $output, $variables) {
 });
 ```
 
+# Wildcards
+
+You can use wildcards to attach the same listener to multiple hooks.
+With wildcards, you can get another parameter `$wildcards` containing an array :
+```php
+Hook::listen('template.*', function($callback, $output, $variables, $wildcards = []) {
+  // For the hook "template.foobar", $wildcards will contain : ["foobar"]
+}):
+```
+
+:exclamation: Warning : the wildcard hook will be executed **only if there is no exact match** for the given hook name.
+<br>For example :
+```php
+Hook::listen('foo', function () {
+  return 'foo';
+});
+Hook::listen('*', function () {
+  return 'wildcard';
+});
+
+Hook::get('foobar'); // => Will return 'wildcard'
+Hook::get('bar'); // => Will return 'wildcard'
+Hook::get('foo'); // => Will return 'foo'
+``` 
 
 # Stop
 ```php

--- a/README.md
+++ b/README.md
@@ -145,11 +145,11 @@ Hook::listen('template.*', function($callback, $output, $variables, $wildcards =
 :exclamation: Warning : the wildcard hook will be executed **only if there is no exact match** for the given hook name.
 <br>For example :
 ```php
-Hook::listen('foo', function () {
-  return 'foo';
-});
 Hook::listen('*', function () {
   return 'wildcard';
+});
+Hook::listen('foo', function () {
+  return 'foo';
 });
 
 Hook::get('foobar'); // => Will return 'wildcard'

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -177,19 +177,41 @@ class Hook
         array_unshift($params, $callback);
 
         if (array_key_exists($hook, $this->watch)) {
-            if (is_array($this->watch[$hook])) {
-                foreach ($this->watch[$hook] as $function) {
-                    if (!empty($this->stop[$hook])) {
-                        unset($this->stop[$hook]);
-                        break;
-                    }
-
-                    $output = call_user_func_array($function['function'], $params);
-                    $params[1] = $output;
+            $output = $this->getOutputForHook($hook, $params, $output);
+        }
+        else {
+            foreach(array_keys($this->watch) as $key) {
+                if(\Illuminate\Support\Str::is($key, $hook)) {
+                    $output = $this->getOutputForHook($key, $params, $output);
+                    break;
                 }
             }
         }
 
+        return $output;
+    }
+
+    /**
+     * Calculate and return the output for the given hook name
+     *
+     * @param string                $hook   Hook name
+     * @param array                 $params Parameters
+     * @param string|null           $output html wrapped by hook
+     * @return mixed
+     */
+    protected function getOutputForHook($hook, $params, $output)
+    {
+        if (is_array($this->watch[$hook])) {
+            foreach ($this->watch[$hook] as $function) {
+                if (!empty($this->stop[$hook])) {
+                    unset($this->stop[$hook]);
+                    break;
+                }
+
+                $output = call_user_func_array($function['function'], $params);
+                $params[1] = $output;
+            }
+        }
         return $output;
     }
 

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -87,6 +87,31 @@ class Hook
     }
 
     /**
+     * Extract and return the words corresponding to wildcard(s) in the hook name pattern
+     *
+     * @param string                $hook       Hook name
+     * @param string                $pattern    Pattern to match against hook name
+     * @return array
+     */
+    protected function getWildcards($hook, $pattern)
+    {
+        $matches = [];
+
+        // Prepare $hook as a regex pattern
+        $hook = '/^' . $hook . '$/';
+        $hook = str_replace('.', '\.', $hook);
+        $hook = str_replace('*', '(.*)', $hook);
+
+        // Try to match wildcards
+        preg_match($hook, $pattern, $matches);
+
+        // Remove first element, containing the full pattern match
+        array_shift($matches);
+
+        return $matches;
+    }
+
+    /**
      * Return all registered hooks.
      *
      * @return array
@@ -177,11 +202,12 @@ class Hook
         array_unshift($params, $callback);
 
         if (array_key_exists($hook, $this->watch)) {
+            array_push($params, []);
             $output = $this->getOutputForHook($hook, $params, $output);
-        }
-        else {
+        } else {
             foreach(array_keys($this->watch) as $key) {
                 if(\Illuminate\Support\Str::is($key, $hook)) {
+                    array_push($params, $this->getWildcards($key, $hook));
                     $output = $this->getOutputForHook($key, $params, $output);
                     break;
                 }

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -3,6 +3,7 @@
 namespace Esemve\Hook;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 class Hook
 {
@@ -206,7 +207,7 @@ class Hook
             $output = $this->getOutputForHook($hook, $params, $output);
         } else {
             foreach(array_keys($this->watch) as $key) {
-                if(\Illuminate\Support\Str::is($key, $hook)) {
+                if(Str::is($key, $hook)) {
                     array_push($params, $this->getWildcards($key, $hook));
                     $output = $this->getOutputForHook($key, $params, $output);
                     break;


### PR DESCRIPTION
I added the possibility to handle wildcards in hook names + I added a "Wildcards" section in README.md

It's not perfect because it matches wildcards ONLY IF there is no exact match (`array_key_exists($hook, $this->watch)`)
and it executes the first wildcard to match, but I still think it can be useful in some use cases !