### PR TITLE
Added ability to get listeners for a specific hook

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "esemve/hook",
-    "description": "Simple hook engine for Laravel 5.*",
+    "description": "Simple hook engine for Laravel 5.*, 6.*",
     "type": "library",
     "keywords": ["Hook","Laravel"],
     "license": "MIT",
@@ -14,7 +14,7 @@
     "minimum-stability": "dev",
 	"require": {
 		"php": ">=5.6",
-		"laravel/framework": "5.*"
+		"laravel/framework": "5.* || 6.*"
     },
     "autoload": {
 		"psr-4": {

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -196,10 +196,14 @@ class Hook
     /**
      * Return the listeners.
      *
+     * @param string $hookName If supplied, only listeners for the specified hook will be returned.
      * @return array
      */
-    public function getListeners()
+    public function getListeners($hookName = null)
     {
-        return $this->watch;
+	if (is_null($hookName)) {
+	    return $this->watch;
+	}
+	return empty($this->watch[$hookName]) ? null : $this->watch[$hookName];
     }
 }

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -201,9 +201,9 @@ class Hook
      */
     public function getListeners($hookName = null)
     {
-	if (is_null($hookName)) {
-	    return $this->watch;
-	}
-	return empty($this->watch[$hookName]) ? null : $this->watch[$hookName];
+        if (is_null($hookName)) {
+            return $this->watch;
+        }
+        return empty($this->watch[$hookName]) ? null : $this->watch[$hookName];
     }
 }


### PR DESCRIPTION
**Changes**

Add ability to retrieve a list of listeners for a specific hook:

`$fooListeners = Hook::getListeners('fooHook');`

**Why?**

We wanted to use hooks to filter an array of values. This is difficult because Hook calls the default internal function in both of these circumstances:

* No listeners were executed
* Listeners were executed, but the output of the listeners was empty.

If no listeners were executed, we want the array to be unfiltered. If listeners were executed and they removed all values from the array, we want the array to be empty. Therefore, we want a different result in each circumstance, but the internal function does not "know" which circumstance has occurred.

The easiest solution is to check whether any listeners have been registered, and then skip the hook entirely if there are no listeners.

Currently this can be done by calling Hook::getListeners() but then the caller needs to do some logic to check whether the relevant array key has been set. It seems neater if getListeners() can take  a hook name and then just return the listeners which are registered for that hook.